### PR TITLE
Add `hold` matcher for Fox

### DIFF
--- a/Source/FoxMatchers.swift
+++ b/Source/FoxMatchers.swift
@@ -1,3 +1,16 @@
-public func foo() -> String {
-    return "foo"
+import Nimble
+import Fox
+
+public func hold(numberOfTests: UInt = FOXGetNumberOfTests()) -> NonNilMatcherFunc<FOXGenerator> {
+    return NonNilMatcherFunc { actualExpression, failureMessage in
+        let property = actualExpression.evaluate()
+
+        let runner = FOXRunner.assertInstance()
+        let result = runner.resultForNumberOfTests(numberOfTests, property: property)
+
+        failureMessage.actualValue = "property"
+        failureMessage.postfixMessage = "hold, but failed for \(result.smallestFailingValue)"
+
+        return result.succeeded
+    }
 }

--- a/Tests/Tests/FoxMatchersSpec.swift
+++ b/Tests/Tests/FoxMatchersSpec.swift
@@ -3,10 +3,23 @@ import Nimble
 import NimbleFox
 import Quick
 
+func forAllIntegers(assertion: (Int, Int) -> Bool) -> FOXGenerator {
+    return forAll(tuple([integer(), integer()])) { tuple in
+        let a = tuple[0] as Int
+        let b = tuple[1] as Int
+
+        return assertion(a, b)
+    }
+}
+
 class FoxMatchersSpec: QuickSpec {
     override func spec() {
-        it("passes") {
-            expect(true).to(beTrue())
+        it("adds pretty matchers for Fox") {
+            let property = forAllIntegers { a, b in
+                a + b == b + a
+            }
+
+            expect(property).to(hold())
         }
     }
 }


### PR DESCRIPTION
`hold` takes an optional number of tests to run. It defaults to the number of
tests set on Fox itself.
